### PR TITLE
코드 리팩토링 #1

### DIFF
--- a/src/main/java/com/rubycon/rubyconteam2/domain/party/controller/PartyController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party/controller/PartyController.java
@@ -42,7 +42,6 @@ public class PartyController {
             @RequestParam("serviceType") @Valid PartyFindRequest partyDto
     ) {
         List<Party> partyList = partyService.findAll(partyDto.getServiceType());
-        if (partyList.isEmpty()) throw new NoContentException();
 
         return partyList.stream()
                 .map(PartyResponse::new)

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party/controller/PartyController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party/controller/PartyController.java
@@ -41,11 +41,7 @@ public class PartyController {
     public List<PartyResponse> findAllParty(
             @RequestParam("serviceType") @Valid PartyFindRequest partyDto
     ) {
-        List<Party> partyList = partyService.findAll(partyDto.getServiceType());
-
-        return partyList.stream()
-                .map(PartyResponse::new)
-                .collect(Collectors.toList());
+        return partyService.findAll(partyDto.getServiceType());
     }
 
     @PostMapping
@@ -58,8 +54,7 @@ public class PartyController {
         if (oAuth2User == null) throw new AuthenticationException();
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
-        Party party = partyService.save(userId, partyDto);
-        return new PartyResponse(party);
+        return partyService.save(userId, partyDto);
     }
 
     @GetMapping("/{partyId}")
@@ -68,8 +63,7 @@ public class PartyController {
     public PartyDetailsResponse findPartyDetails(
             @PathVariable final Long partyId
     ){
-        List<PartyJoin> partyJoins = partyJoinService.findAllByPartyId(partyId);
-        return new PartyDetailsResponse(partyJoins);
+        return partyJoinService.findAllByPartyId(partyId);
     }
 
     @PutMapping("/{partyId}")
@@ -79,8 +73,7 @@ public class PartyController {
             @PathVariable final Long partyId,
             @RequestBody @Valid PartyUpdateRequest partyDto
     ){
-        Party party = partyService.update(partyId, partyDto);
-        return new PartyResponse(party);
+        return partyService.update(partyId, partyDto);
     }
 
     @DeleteMapping("/{partyId}")

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party/dto/response/PartyResponse.java
@@ -5,12 +5,12 @@ import com.rubycon.rubyconteam2.domain.party.domain.PartyState;
 import com.rubycon.rubyconteam2.domain.party.domain.PaymentCycle;
 import com.rubycon.rubyconteam2.domain.party.domain.ServiceType;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class PartyResponse {
 
     @ApiModelProperty(value = "파티 ID", required = true, example = "1")

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party/service/PartyService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party/service/PartyService.java
@@ -13,6 +13,7 @@ import com.rubycon.rubyconteam2.domain.party_join.exception.PartyJoinNotFoundExc
 import com.rubycon.rubyconteam2.domain.user.domain.User;
 import com.rubycon.rubyconteam2.domain.user.exception.UserNotFoundException;
 import com.rubycon.rubyconteam2.domain.user.repository.UserRepository;
+import com.rubycon.rubyconteam2.global.error.exception.NoContentException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,23 +34,18 @@ public class PartyService {
     /**
      * 서비스 타입에 따른 전체 모집 중 파티 검색
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Party> findAll(ServiceType serviceType) {
-        return partyRepository.findByServiceTypeIs(serviceType);
-    }
+        List<Party> partyList = partyRepository.findByServiceTypeIs(serviceType);
+        if (partyList.isEmpty()) throw new NoContentException();
 
-    /**
-     * 특정 파티 1개 조회
-     */
-    @Transactional
-    public Party findById(Long partyId) {
-        return partyRepository.findById(partyId)
-                .orElseThrow(PartyNotFoundException::new);
+        return partyList;
     }
 
     /**
      * 모집 파티 생성 + 파티장 권한으로 가입
      * TODO : 파티는 각 서비스별 1개씩만 가입 되어있어야함!!
+     * user id만으로 save?
      */
     @Transactional
     public Party save(Long userId, PartyCreateRequest partyDto){
@@ -68,7 +64,8 @@ public class PartyService {
      */
     @Transactional
     public Party update(Long partyId, PartyUpdateRequest partyDto){
-        Party party = this.findById(partyId);
+        Party party = partyRepository.findById(partyId)
+                .orElseThrow(PartyNotFoundException::new);
         party.updateMyParty(partyDto);
 
         return partyRepository.save(party);
@@ -81,7 +78,8 @@ public class PartyService {
     public void delete(Long userId, Long partyId){
         userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        Party party = this.findById(partyId);
+        Party party = partyRepository.findById(partyId)
+                .orElseThrow(PartyNotFoundException::new);
 
         PartyState partyState = party.getPartyState();
         if (partyState.isDeleted()) throw new PartyNotProceedingException();

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party_join/controller/PartyJoinController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party_join/controller/PartyJoinController.java
@@ -37,11 +37,7 @@ public class PartyJoinController {
         if (oAuth2User == null) throw new AuthenticationException();
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
-        List<PartyJoin> partyJoins = partyJoinService.findAllMyPartyByState(userId, profileDto.getPartyState());
-
-        return partyJoins.stream()
-                .map(PartyWithRoleResponse::new)
-                .collect(Collectors.toList());
+        return partyJoinService.findAllMyPartyByState(userId, profileDto.getPartyState());
     }
 
     @PostMapping("/{partyId}/join")
@@ -54,8 +50,7 @@ public class PartyJoinController {
         if (oAuth2User == null) throw new AuthenticationException();
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
-        PartyJoin partyJoin = partyJoinService.join(userId, partyId);
-        return new PartyJoinResponse(partyJoin);
+        return partyJoinService.join(userId, partyId);
     }
 
     @DeleteMapping("/{partyId}/leave")

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party_join/dto/response/PartyDetailsResponse.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party_join/dto/response/PartyDetailsResponse.java
@@ -18,12 +18,7 @@ public class PartyDetailsResponse {
     private PartyResponse party;
     private List<ProfileWithRoleResponse> users = new ArrayList<>();
 
-    public PartyDetailsResponse(List<PartyJoin> partyJoins) {
-        Party party = partyJoins.stream()
-                .findFirst()
-                .map(PartyJoin::getParty)
-                .orElseGet(Party::new);
-
+    public PartyDetailsResponse(Party party, List<PartyJoin> partyJoins) {
         this.party = new PartyResponse(party);
 
         partyJoins.forEach(partyJoin -> this.users.add(new ProfileWithRoleResponse(partyJoin)));

--- a/src/main/java/com/rubycon/rubyconteam2/domain/party_join/service/PartyJoinService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/party_join/service/PartyJoinService.java
@@ -137,7 +137,7 @@ public class PartyJoinService {
     /**
      * 특정 사용자가 가입한 파티 조회 ( 파티 상태 별 )
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PartyJoin> findAllMyPartyByState(Long userId, PartyState partyState) {
         userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
@@ -148,7 +148,7 @@ public class PartyJoinService {
     /**
      * 파티 상세 조회 (파티 정보 + 가입한 유저 정보)
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PartyJoin> findAllByPartyId(Long partyId) {
         partyRepository.findById(partyId)
                 .orElseThrow(PartyNotFoundException::new);
@@ -162,7 +162,7 @@ public class PartyJoinService {
     /**
      * 현재 내가 리뷰 가능한 사용자 리스트 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PartyJoin> findAllReviewableUsers(Long userId, Long partyId){
         userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/rubycon/rubyconteam2/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/review/controller/ReviewController.java
@@ -39,10 +39,7 @@ public class ReviewController {
         if (oAuth2User == null) throw new AuthenticationException();
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
-        List<PartyJoin> partyJoins = partyJoinService.findAllReviewableUsers(userId, partyId);
-        return partyJoins.stream()
-                .map(ProfileWithRoleResponse::new)
-                .collect(Collectors.toList());
+        return partyJoinService.findAllReviewableUsers(userId, partyId);
     }
 
     @PostMapping("/{partyId}/users/{targetId}/review")

--- a/src/main/java/com/rubycon/rubyconteam2/domain/review/service/ReviewService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/review/service/ReviewService.java
@@ -68,7 +68,7 @@ public class ReviewService {
      * @param targetId 리뷰 조회할 사용자 ID
      * @return
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Review> findAllReview(Long targetId){
         return reviewQueryRepository.findAllReviewByTargetId(targetId);
     }

--- a/src/main/java/com/rubycon/rubyconteam2/domain/review/service/ReviewService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/review/service/ReviewService.java
@@ -12,6 +12,7 @@ import com.rubycon.rubyconteam2.domain.review.exception.ReviewDuplicatedExceptio
 import com.rubycon.rubyconteam2.domain.review.repository.ReviewQueryRepository;
 import com.rubycon.rubyconteam2.domain.review.repository.ReviewRepository;
 import com.rubycon.rubyconteam2.domain.user.domain.User;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileReviewResponse;
 import com.rubycon.rubyconteam2.domain.user.exception.UserNotFoundException;
 import com.rubycon.rubyconteam2.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -69,7 +70,8 @@ public class ReviewService {
      * @return
      */
     @Transactional(readOnly = true)
-    public List<Review> findAllReview(Long targetId){
-        return reviewQueryRepository.findAllReviewByTargetId(targetId);
+    public ProfileReviewResponse findAllReview(Long targetId){
+        List<Review> reviews = reviewQueryRepository.findAllReviewByTargetId(targetId);
+        return new ProfileReviewResponse(reviews);
     }
 }

--- a/src/main/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileController.java
@@ -36,9 +36,7 @@ public class ProfileController {
         if (oAuth2User == null) throw new AuthenticationException();
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
-        User user = userService.findById(userId);
-
-        return new ProfileResponse(user);
+        return userService.findById(userId);
     }
 
     // TODO : 권한 허용
@@ -48,8 +46,6 @@ public class ProfileController {
     public ProfileReviewResponse findAllReview(
             @PathVariable final Long userId
     ){
-        List<Review> reviews = reviewService.findAllReview(userId);
-
-        return new ProfileReviewResponse(reviews);
+        return reviewService.findAllReview(userId);
     }
 }

--- a/src/main/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileController.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileController.java
@@ -37,6 +37,7 @@ public class ProfileController {
 
         Long userId = oAuth2User.getAttribute(OAuthConstants.KEY);
         User user = userService.findById(userId);
+
         return new ProfileResponse(user);
     }
 

--- a/src/main/java/com/rubycon/rubyconteam2/domain/user/dto/response/ProfileReviewResponse.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/user/dto/response/ProfileReviewResponse.java
@@ -2,13 +2,11 @@ package com.rubycon.rubyconteam2.domain.user.dto.response;
 
 import com.rubycon.rubyconteam2.domain.review.domain.Content;
 import com.rubycon.rubyconteam2.domain.review.domain.ContentType;
-import com.rubycon.rubyconteam2.domain.review.domain.Rating;
 import com.rubycon.rubyconteam2.domain.review.domain.Review;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,26 +15,15 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileReviewResponse {
 
-    private List<ReviewGroupByType> reviews = new ArrayList<>();;
+    private List<ReviewGroupByType> reviews = new ArrayList<>();
 
     public ProfileReviewResponse(List<Review> reviews) {
         Map<Content, Long> groups = Review.groupingByContent(reviews);
 
-        for (ContentType type : ContentType.values()){
-            Map<Content, Long> group = groups.entrySet().stream()
-                    .filter(e -> e.getKey().getContentType().equals(type))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            ReviewGroupByType reviewGroupByType =
-                    ReviewGroupByType.builder()
-                        .type(type)
-                        .review(group)
-                        .build();
-
-            this.reviews.add(reviewGroupByType);
+        for (ContentType type : ContentType.values()) {
+            ReviewGroupByType review = ReviewGroupByType.of(type, groups);
+            this.reviews.add(review);
         }
-//        Map<ContentType, List<Map.Entry<Content, Long>>> response = groups.entrySet().stream()
-//                .collect(Collectors.groupingBy(o-> o.getKey().getContentType()));
     }
 
     @Getter
@@ -54,5 +41,16 @@ public class ProfileReviewResponse {
                 reference = "Map"
         )
         private Map<Content, Long> review;
+
+        public static ReviewGroupByType of(ContentType type, Map<Content, Long> groups) {
+            Map<Content, Long> reviewWithCount = groups.entrySet().stream()
+                    .filter(e -> e.getKey().getContentType().equals(type))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            return ReviewGroupByType.builder()
+                    .type(type)
+                    .review(reviewWithCount)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/rubycon/rubyconteam2/domain/user/service/UserService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/user/service/UserService.java
@@ -31,10 +31,9 @@ public class UserService {
     /**
      * User 검색
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public User findById(Long userId){
-        User user = userRepository.findById(userId)
+        return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        return user;
     }
 }

--- a/src/main/java/com/rubycon/rubyconteam2/domain/user/service/UserService.java
+++ b/src/main/java/com/rubycon/rubyconteam2/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.rubycon.rubyconteam2.domain.user.service;
 
 import com.rubycon.rubyconteam2.domain.user.domain.User;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileResponse;
 import com.rubycon.rubyconteam2.domain.user.exception.UserNotFoundException;
 import com.rubycon.rubyconteam2.domain.user.repository.UserRepository;
 import com.rubycon.rubyconteam2.infra.sms.dto.request.NCPVerifyRequest;
@@ -32,8 +33,9 @@ public class UserService {
      * User 검색
      */
     @Transactional(readOnly = true)
-    public User findById(Long userId){
-        return userRepository.findById(userId)
+    public ProfileResponse findById(Long userId){
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+        return new ProfileResponse(user);
     }
 }

--- a/src/test/java/com/rubycon/rubyconteam2/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/rubycon/rubyconteam2/domain/party/controller/PartyControllerTest.java
@@ -5,7 +5,9 @@ import com.rubycon.rubyconteam2.domain.party.domain.ServiceType;
 import com.rubycon.rubyconteam2.domain.party.dto.request.PartyCreateRequest;
 import com.rubycon.rubyconteam2.domain.party.dto.request.PartyFindRequest;
 import com.rubycon.rubyconteam2.domain.party.dto.request.PartyUpdateRequest;
+import com.rubycon.rubyconteam2.domain.party.dto.response.PartyResponse;
 import com.rubycon.rubyconteam2.domain.party_join.domain.PartyJoin;
+import com.rubycon.rubyconteam2.domain.party_join.dto.response.PartyDetailsResponse;
 import com.rubycon.rubyconteam2.global.common.WebMvcApiTest;
 import com.rubycon.rubyconteam2.global.common.WithMockCustomUser;
 import com.rubycon.rubyconteam2.global.factory.TestPartyFactory;
@@ -15,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -31,9 +34,12 @@ class PartyControllerTest extends WebMvcApiTest {
         PartyFindRequest partyDto = TestPartyFactory.findPartyDto();
 
         List<Party> partyList = TestPartyFactory.findAllNetflixParties();
+        List<PartyResponse> partyResponseList = partyList.stream()
+                .map(PartyResponse::new)
+                .collect(Collectors.toList());
 
         given(partyService.findAll(any(ServiceType.class)))
-                .willReturn(partyList);
+                .willReturn(partyResponseList);
 
         // When & Then
         mockMvc.perform(get("/party")
@@ -53,8 +59,10 @@ class PartyControllerTest extends WebMvcApiTest {
         PartyCreateRequest partyDto = TestPartyFactory.createPartyDto();
 
         Party party = partyDto.toEntity();
+        PartyResponse partyResponse = new PartyResponse(party);
+
         given(partyService.save(any(Long.class), any(PartyCreateRequest.class)))
-                .willReturn(party);
+                .willReturn(partyResponse);
 
         // When & Then
         mockMvc.perform(post("/party")
@@ -73,10 +81,12 @@ class PartyControllerTest extends WebMvcApiTest {
         // Given
         int partyId = 1;
 
+        Party party = TestPartyFactory.createParty(1L, ServiceType.APPLE_MUSIC);
         List<PartyJoin> partyJoins = TestPartyJoinFactory.findAllPartyJoins();
+        PartyDetailsResponse partyDetailsResponse = new PartyDetailsResponse(party, partyJoins);
 
         given(partyJoinService.findAllByPartyId(any(Long.class)))
-                .willReturn(partyJoins);
+                .willReturn(partyDetailsResponse);
 
         // When & Then
         mockMvc.perform(get("/party/{partyId}", partyId)
@@ -98,9 +108,10 @@ class PartyControllerTest extends WebMvcApiTest {
 
         Party party = TestPartyFactory.createParty(1L, ServiceType.APPLE_MUSIC);
         party.updateMyParty(partyDto);
+        PartyResponse partyResponse = new PartyResponse(party);
 
         given(partyService.update(any(Long.class), any(PartyUpdateRequest.class)))
-                .willReturn(party);
+                .willReturn(partyResponse);
 
         // When & Then
         mockMvc.perform(put("/party/{partyId}", partyId)

--- a/src/test/java/com/rubycon/rubyconteam2/domain/party_join/controller/PartyJoinControllerTest.java
+++ b/src/test/java/com/rubycon/rubyconteam2/domain/party_join/controller/PartyJoinControllerTest.java
@@ -1,9 +1,13 @@
 package com.rubycon.rubyconteam2.domain.party_join.controller;
 
 import com.rubycon.rubyconteam2.domain.party.domain.Party;
+import com.rubycon.rubyconteam2.domain.party.domain.PartyState;
 import com.rubycon.rubyconteam2.domain.party.domain.ServiceType;
 import com.rubycon.rubyconteam2.domain.party_join.domain.PartyJoin;
 import com.rubycon.rubyconteam2.domain.party_join.domain.Role;
+import com.rubycon.rubyconteam2.domain.party_join.dto.request.MyPartyRequest;
+import com.rubycon.rubyconteam2.domain.party_join.dto.response.PartyJoinResponse;
+import com.rubycon.rubyconteam2.domain.party_join.dto.response.PartyWithRoleResponse;
 import com.rubycon.rubyconteam2.domain.user.domain.User;
 import com.rubycon.rubyconteam2.global.common.WebMvcApiTest;
 import com.rubycon.rubyconteam2.global.common.WithMockCustomUser;
@@ -13,8 +17,12 @@ import com.rubycon.rubyconteam2.global.factory.TestUserFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -24,14 +32,42 @@ class PartyJoinControllerTest extends WebMvcApiTest {
 
     @Test
     @WithMockCustomUser
+    void findAllMyParty() throws Exception {
+        // Given
+        MyPartyRequest partyDto = MyPartyRequest.builder()
+                .partyState(PartyState.RECRUITING.name())
+                .build();
+
+        List<PartyJoin> partyJoins = TestPartyJoinFactory.findAllPartyJoins();
+        List<PartyWithRoleResponse> responses = partyJoins.stream()
+                .map(PartyWithRoleResponse::new)
+                .collect(Collectors.toList());
+
+        given(partyJoinService.findAllMyPartyByState(any(Long.class), any(PartyState.class)))
+                .willReturn(responses);
+
+        // When & Then
+        mockMvc.perform(get("/party/me")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .param("partyState", partyDto.getPartyState().name()))
+                .andDo(print())
+                .andExpect(status().isOk())
+        ;
+    }
+
+    @Test
+    @WithMockCustomUser
     void joinParty() throws Exception {
         // Given
         User user = TestUserFactory.createUser(1L);
         Party party = TestPartyFactory.createParty(1L, ServiceType.NETFLIX);
         PartyJoin partyJoin = TestPartyJoinFactory.createPartyJoin(user, party, Role.MEMBER);
+        PartyJoinResponse partyJoinResponse = new PartyJoinResponse(partyJoin);
 
         given(partyJoinService.join(any(Long.class), any(Long.class)))
-                .willReturn(partyJoin);
+                .willReturn(partyJoinResponse);
 
         int partyId = 1;
         // When & Then
@@ -52,6 +88,23 @@ class PartyJoinControllerTest extends WebMvcApiTest {
 
         // When & Then
         mockMvc.perform(delete("/party/{partyId}/leave", partyId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+        ;
+    }
+
+    @Test
+    @WithMockCustomUser
+    void kickOff() throws Exception {
+        // Given
+        int partyId = 1;
+        int targetId = 1;
+
+        // When & Then
+        mockMvc.perform(delete("/party/{partyId}/users/{targetId}/kick-off", partyId, targetId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .characterEncoding("UTF-8"))

--- a/src/test/java/com/rubycon/rubyconteam2/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/rubycon/rubyconteam2/domain/review/controller/ReviewControllerTest.java
@@ -2,6 +2,8 @@ package com.rubycon.rubyconteam2.domain.review.controller;
 
 import com.rubycon.rubyconteam2.domain.party_join.domain.PartyJoin;
 import com.rubycon.rubyconteam2.domain.review.dto.request.ReviewRequest;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileReviewResponse;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileWithRoleResponse;
 import com.rubycon.rubyconteam2.global.common.WebMvcApiTest;
 import com.rubycon.rubyconteam2.global.common.WithMockCustomUser;
 import com.rubycon.rubyconteam2.global.factory.TestPartyJoinFactory;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -23,10 +26,13 @@ class ReviewControllerTest extends WebMvcApiTest {
     @WithMockCustomUser
     void findReviewableUsers() throws Exception {
         // Given
-        List<PartyJoin> partyJoinList = TestPartyJoinFactory.findAllPartyJoins();
+        List<PartyJoin> partyJoins = TestPartyJoinFactory.findAllPartyJoins();
+        List<ProfileWithRoleResponse> responses = partyJoins.stream()
+                .map(ProfileWithRoleResponse::new)
+                .collect(Collectors.toList());
 
         given(partyJoinService.findAllReviewableUsers(1L, 1L))
-                .willReturn(partyJoinList);
+                .willReturn(responses);
 
         int partyId = 1;
         // When & Then

--- a/src/test/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileControllerTest.java
+++ b/src/test/java/com/rubycon/rubyconteam2/domain/user/controller/ProfileControllerTest.java
@@ -2,6 +2,8 @@ package com.rubycon.rubyconteam2.domain.user.controller;
 
 import com.rubycon.rubyconteam2.domain.review.domain.Review;
 import com.rubycon.rubyconteam2.domain.user.domain.User;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileResponse;
+import com.rubycon.rubyconteam2.domain.user.dto.response.ProfileReviewResponse;
 import com.rubycon.rubyconteam2.global.common.WebMvcApiTest;
 import com.rubycon.rubyconteam2.global.common.WithMockCustomUser;
 import com.rubycon.rubyconteam2.global.factory.TestReviewFactory;
@@ -23,9 +25,10 @@ class ProfileControllerTest extends WebMvcApiTest {
     void me() throws Exception {
         // Given
         User user = TestUserFactory.createUser(1L);
+        ProfileResponse response = new ProfileResponse(user);
 
         given(userService.findById(1L))
-                .willReturn(user);
+                .willReturn(response);
 
         // When & Then
         mockMvc.perform(get("/profiles/me")
@@ -41,9 +44,10 @@ class ProfileControllerTest extends WebMvcApiTest {
     void findAllReview() throws Exception {
         // Given
         List<Review> reviews = TestReviewFactory.findAllReviews();
+        ProfileReviewResponse response = new ProfileReviewResponse(reviews);
 
         given(reviewService.findAllReview(1L))
-                .willReturn(reviews);
+                .willReturn(response);
 
         int userId = 1;
         // When & Then


### PR DESCRIPTION
## Transaction(readOnly=true)
- 검색만 하는 비즈니스 로직은 위의 RO 조건 걸기
- flushmode가 변경되어 (`COMMIT`) 트랜잭션 commit 시에 플러시가 안일어나서 최적화
  - 하이버네이트에서는 `MANUAL`

## Service Layer에서 Domain -> DTO 반환하도록 변경
- 서비스 레이어는 application의 경계를 정의하고 도메인을 캡슐화한다. 즉 도메인을 보호한다
- 컨트롤러 레이어에서 도메인을 사용하면 결합도가 증가해 코드변경이 일어날 수 있음
 단, 도메인 모델과 거의 비슷한 DTO를 만드는 코드 중복이 일어난다.